### PR TITLE
Fix missing package init

### DIFF
--- a/sociology_simulation/__init__.py
+++ b/sociology_simulation/__init__.py
@@ -1,0 +1,5 @@
+"""Initialize sociology_simulation package"""
+
+# Expose key components for convenience
+from .world import World  # noqa: F401
+from .trinity import Trinity  # noqa: F401

--- a/sociology_simulation/config.py
+++ b/sociology_simulation/config.py
@@ -151,3 +151,7 @@ DEFAULT_RESOURCE_RULES = {                      # Will be deprecated
     "stone": {"MOUNTAIN": 0.6},
     "magical_crystal": {"MOUNTAIN": 0.1, "FOREST": 0.05}
 }
+
+# Legacy alias
+from .enhanced_llm import init_llm_service
+


### PR DESCRIPTION
## Summary
- expose package root for `sociology_simulation`
- re-export `init_llm_service` from config module

## Testing
- `pytest sociology_simulation/tests/test_core_systems.py::TestAgentState::test_agent_creation -q`
- `pytest -q` *(fails: Configuration not initialized, async tests unsupported)*

------
https://chatgpt.com/codex/tasks/task_e_6869f8d619f083269daa07ca4c20277f