### PR TITLE
Fix template braces

### DIFF
--- a/sociology_simulation/conf/prompts.yaml
+++ b/sociology_simulation/conf/prompts.yaml
@@ -252,7 +252,7 @@ templates:
       2. No trailing commas or comments
       3. Ensure all brackets and braces are closed
       4. Numbers must be valid (e.g., 1 not "1")
-      5. If unsure, output an empty object {}
+      5. If unsure, output an empty object {{}}
 
       Required JSON format:
       {{
@@ -364,7 +364,7 @@ templates:
       **Requirements:**
       - Only return repaired JSON
       - No explanations or extra text
-      - If unrepairable, return {}
+      - If unrepairable, return {{}}
     
     user: |
       Please repair the following JSON:


### PR DESCRIPTION
## Summary
- fix unescaped braces in `prompts.yaml`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6869fc55909c8326941bae1b61a7ab13