### PR TITLE
Improve name generation

### DIFF
--- a/sociology_simulation/agent.py
+++ b/sociology_simulation/agent.py
@@ -147,23 +147,38 @@ class Agent:
         
         return connection_influence + reputation_influence + skill_influence
     
-    async def generate_name(self, session: aiohttp.ClientSession, era: str = "石器时代"):
+    async def generate_name(
+        self,
+        session: aiohttp.ClientSession,
+        era: str = "石器时代",
+        goal: str = "",
+    ):
         """Generate agent name using enhanced LLM service"""
         llm_service = get_llm_service()
-        self.name = await llm_service.generate_agent_name(era, self.attributes, self.age, session)
+        self.name = await llm_service.generate_agent_name(
+            era,
+            self.attributes,
+            self.age,
+            session,
+            goal=goal,
+        )
 
     async def decide_goal(self, era_prompt: str, session: aiohttp.ClientSession):
         """Determine agent's personal goal using enhanced LLM service"""
         if self.goal:
             return
         
-        if not self.name:
-            await self.generate_name(session, era_prompt)
-            
         llm_service = get_llm_service()
         self.goal = await llm_service.generate_agent_goal(
-            era_prompt, self.attributes, self.age, self.inventory, session
+            era_prompt,
+            self.attributes,
+            self.age,
+            self.inventory,
+            session,
         )
+
+        await self.generate_name(session, era_prompt, goal=self.goal)
+
         formatter = get_formatter()
         logger.info(formatter.format_agent_goal(self.name, self.aid, self.goal))
 

--- a/sociology_simulation/conf/prompts.yaml
+++ b/sociology_simulation/conf/prompts.yaml
@@ -5,20 +5,21 @@ templates:
   # ========== Agent Related Prompts ==========
   agent_generate_name:
     system: |
-      You are a professional name generator that creates appropriate names for characters in simulation worlds based on era background. Always generate English names that fit the era style.
-      
+      You are a professional name generator that creates appropriate names for characters in simulation worlds based on era background. Names should reflect a character's attributes and personal goal.
+
       Requirements:
       1. Names must fit the era background
-      2. Consider character attribute traits
+      2. Consider character attribute traits and the stated goal
       3. Names should be simple and memorable
       4. Only output the name, no explanations
-    
+
     user: |
       Era background: {era}
       Character attributes: {attributes}
+      Character goal: {goal}
       Character age: {age}
-      
-      For Stone Age era, use simple English names like: Rok, Flint, Ash, Reed, Clay, Storm, etc.
+
+      For the Stone Age era, prefer short English names. Use the attributes and goal for inspiration and avoid reusing the same names.
       Generate a suitable English name for this character:
     
     temperature: 0.8

--- a/sociology_simulation/enhanced_llm.py
+++ b/sociology_simulation/enhanced_llm.py
@@ -473,14 +473,22 @@ IF YOU CANNOT GENERATE VALID JSON, RETURN: {}
     
     # === 便捷方法 ===
     
-    async def generate_agent_name(self, era: str, attributes: Dict, age: int, session: aiohttp.ClientSession) -> str:
+    async def generate_agent_name(
+        self,
+        era: str,
+        attributes: Dict,
+        age: int,
+        session: aiohttp.ClientSession,
+        goal: str = "",
+    ) -> str:
         """生成Agent名字"""
         response = await self.generate(
             "agent_generate_name",
             session,
             era=era,
             attributes=attributes,
-            age=age
+            age=age,
+            goal=goal,
         )
         return response.content if response.success else f"Agent{age}"
     


### PR DESCRIPTION
## Summary
- incorporate agent goals when generating names
- pass goal information to the LLM
- regenerate agent names after goals are set

## Testing
- `pip install aiohttp loguru matplotlib openai hydra-core numpy websockets`
- `pytest -q` *(fails: ImportError: cannot import name 'init_llm_service')*

------
https://chatgpt.com/codex/tasks/task_e_6869fee558e083269f1ae812deea231d