### PR TITLE
feat(agent): enable dynamic numeric state variables

### DIFF
--- a/DETAILED_DEVELOPMENT_PLAN.md
+++ b/DETAILED_DEVELOPMENT_PLAN.md
@@ -1,0 +1,72 @@
+# Simulation Improvement Parallel Development Plan
+
+## Overview
+This plan breaks down the current bottlenecks and missing features in the sociology simulation
+into three workstreams. Each stream can be developed in parallel by one developer and includes
+code targets, acceptance tests, and coordination notes.
+
+### Goals
+- Faster, deterministic world initialization with meaningful terrain and resource variety.
+- Agents capable of gathering and consuming resources while Trinity reliably seeds default skills.
+- Autonomous evolution events (skills, rules, weather) and a probabilistic reproduction system.
+
+## Workstream A – Initialization & Environment Diversity *(Dev A)*
+
+**Scope**: `world.py`, `terrain_generator.py`, `trinity.py` (rule generation portions), related tests.
+
+1. **Eliminate initialization polling**
+   - In `World.initialize`, replace the `while not hasattr(self.trinity, 'resource_rules')` loop with a
+     synchronous call that raises on failure.
+   - Ensure `_generate_initial_rules` sets `resource_rules` and `terrain_types` before returning.
+2. **Configurable terrain generation**
+   - Add a `terrain.algorithm` option ("simple" | "realistic") and default to simple.
+   - Cache results for deterministic seeds to speed up repeated runs.
+3. **Improve terrain/resource diversity**
+   - After `_generate_initial_rules`, validate that multiple terrain and resource types exist; if not,
+     fall back to `DEFAULT_TERRAIN` and `DEFAULT_RESOURCES`.
+   - Update `terrain_generator._classify_terrain` to randomize classification when types are scarce.
+4. **Testing**
+   - Add unit test verifying initialization finishes without polling and that at least two terrain types
+     appear on a 16x16 map.
+
+## Workstream B – Resource Interaction & Trinity Reliability *(Dev B)*
+
+**Scope**: `world.py`, `action_handler.py` (if separated), `prompts.py`, `trinity.py`, relevant tests.
+
+1. **Agent-driven gather/consume actions**
+   - Extend `ActionHandler` with a dispatch table for actions (`gather`, `consume`, etc.).
+   - On `gather_request`, transfer resources from `World.resources` to `agent.inventory`.
+   - On `consume_request`, decrement inventory and reduce `agent.hunger`.
+2. **Expose hunger configuration**
+   - Add `hunger_growth_rate` to config with a lower default.
+   - Remove automatic food consumption in `World.step`; rely on explicit `consume` actions.
+3. **Seed Trinity with core skills**
+   - Populate `Trinity.available_skills` with `move`, `gather`, `consume`, etc. during `__init__`.
+   - Ensure `_generate_initial_rules` never clears these defaults even if LLM fails.
+4. **Prompt updates**
+   - Update `prompts.py` to advertise `gather` and `consume` actions and clarify hunger consequences.
+5. **Testing**
+   - Add tests confirming an agent can gather a resource and lower hunger by consuming it.
+
+## Workstream C – Evolution & Reproduction Systems *(Dev C)*
+
+**Scope**: `world.py`, `trinity.py`, `agent.py`, tests.
+
+1. **Periodic evolution hooks**
+   - In `Trinity.execute_actions`, trigger weather or rule evolution every N turns even when LLM
+     returns nothing. Provide deterministic fallbacks.
+2. **Default numeric state variables**
+   - Extend `Agent` with `stamina` and `cooldowns: Dict[str, int]`.
+   - `ActionHandler` deducts stamina or sets cooldowns when actions specify costs.
+3. **Reproduction mechanism**
+   - Allow Trinity to propose reproduction pairs based on health/inventory.
+   - Update `World.step` to process these suggestions with probability instead of mutual consent.
+   - Initialize offspring with random attributes and log births.
+4. **Testing**
+   - Add integration test running several turns to ensure population can grow when agents are healthy.
+
+## Coordination Notes
+- Each developer should run `uv run ruff check .` and `uv run pytest -q` before submitting PRs.
+- Interfaces between workstreams (`ActionHandler` API, Trinity hooks) must remain backward compatible.
+- Weekly sync to integrate changes and resolve merge conflicts.
+

--- a/sociology_simulation/tests/test_numeric_state.py
+++ b/sociology_simulation/tests/test_numeric_state.py
@@ -1,0 +1,42 @@
+import aiohttp
+import pytest
+from types import SimpleNamespace
+
+from sociology_simulation.agent import Agent
+from sociology_simulation.world import World
+from sociology_simulation.bible import Bible
+from sociology_simulation.trinity import Trinity
+
+
+@pytest.mark.asyncio
+async def test_action_handler_applies_numeric_state_changes():
+    agent = Agent(1, (0, 0), {}, {})
+    world_stub = SimpleNamespace(pending_interactions=[])
+    handler = World.ActionHandler(Bible(), world_stub)
+    async with aiohttp.ClientSession() as session:
+        await handler._process_outcome(
+            {
+                "state_updates": {"stamina": 10},
+                "state_deltas": {"stamina": -3, "energy": 5},
+                "state_remove": ["energy"],
+            },
+            agent,
+            world_stub,
+            session,
+            "",
+        )
+    assert agent.get_numeric_state("stamina") == 7.0
+    assert "energy" not in agent.numeric_states
+
+
+def test_trinity_can_modify_numeric_state():
+    bible = Bible()
+    trinity = Trinity(bible, "Stone Age")
+    agent = Agent(2, (0, 0), {}, {})
+    trinity.update_agent_numeric_state(agent, updates={"stamina": 5})
+    assert agent.get_numeric_state("stamina") == 5.0
+    trinity.update_agent_numeric_state(agent, deltas={"stamina": -2})
+    assert agent.get_numeric_state("stamina") == 3.0
+    trinity.update_agent_numeric_state(agent, remove=["stamina"])
+    assert agent.get_numeric_state("stamina") == 0.0
+    assert "stamina" not in agent.numeric_states

--- a/sociology_simulation/trinity.py
+++ b/sociology_simulation/trinity.py
@@ -1,15 +1,15 @@
 """Trinity class for generating world rules"""
-import asyncio
 import random
-import json
 import aiohttp
-from typing import Dict, List, Any
-from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
 from loguru import logger
 
 from .config import DEFAULT_TERRAIN, DEFAULT_RESOURCE_RULES
 from .enhanced_llm import get_llm_service
 from .bible import Bible
+
+if TYPE_CHECKING:
+    from .agent import Agent
 
 class Trinity:
     """World rules generator class
@@ -252,7 +252,7 @@ class Trinity:
         for skill_name, changes in skill_changes.items():
             if "unlock" in changes:
                 if skill_name not in agent.skills:
-                    agent.add_skill(skill_name, changes["unlock"].get("level", 1), 
+                    agent.add_skill(skill_name, changes["unlock"].get("level", 1),
                                    changes["unlock"].get("description", ""))
                     logger.info(f"[Trinity] Agent {agent.aid} unlocked skill: {skill_name}")
             
@@ -264,3 +264,24 @@ class Trinity:
             if "remove" in changes:
                 agent.remove_skill(skill_name, changes["remove"].get("reason", ""))
                 logger.info(f"[Trinity] Agent {agent.aid} lost skill: {skill_name}")
+
+    def update_agent_numeric_state(
+        self,
+        agent: "Agent",
+        updates: Optional[Dict[str, float]] = None,
+        deltas: Optional[Dict[str, float]] = None,
+        remove: Optional[List[str]] = None,
+    ) -> None:
+        """Allow Trinity to modify an agent's numeric state variables"""
+
+        if updates:
+            for name, value in updates.items():
+                agent.set_numeric_state(name, value)
+
+        if deltas:
+            for name, delta in deltas.items():
+                agent.adjust_numeric_state(name, delta)
+
+        if remove:
+            for name in remove:
+                agent.remove_numeric_state(name)


### PR DESCRIPTION
## Summary
- allow agents to store arbitrary numeric state via set/adjust/remove helpers
- let Trinity update agent numeric state and ActionHandler apply state changes from outcomes
- add tests ensuring dynamic state creation, modification, and removal

## Testing
- `uv run ruff check sociology_simulation/agent.py sociology_simulation/world.py sociology_simulation/trinity.py sociology_simulation/tests/test_numeric_state.py`
- `uv run pytest sociology_simulation/tests/test_numeric_state.py -q`
- `uv run pytest -q` *(fails: missing `init_llm_service` import and missing `websockets` dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68bed8952af083268018852e004722cc