### PR TITLE
Integrate pixel map and roster into monitor console

### DIFF
--- a/web_ui/monitor/src/components/map/MapPanel.tsx
+++ b/web_ui/monitor/src/components/map/MapPanel.tsx
@@ -1,52 +1,447 @@
 import "../../styles/panel.css";
-import { useMemo } from "react";
-import { selectCurrentTurn, useSimulationStore } from "../../state/store";
+import "../../styles/map-panel.css";
+import type { MouseEvent } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  selectAgents,
+  selectCurrentTurn,
+  selectSelectedAgentId,
+  selectSelectedTile,
+  useSimulationStore
+} from "../../state/store";
+import type { AgentSummary, TileResources, WorldState } from "../../types/simulation";
 
-const GRID_SIZE = 20;
+const TILE_SIZE = 16;
+const TERRAIN_COLORS: Record<string, string> = {
+  MOUNTAIN: "#4c4f69",
+  FOREST: "#2f7e4d",
+  GRASSLAND: "#4c9c58",
+  PLAINS: "#6ea45a",
+  DESERT: "#c8a15a",
+  WATER: "#2d5b9c",
+  SWAMP: "#3f6854",
+  TUNDRA: "#9ba7b7",
+  DEFAULT: "#506070"
+};
+
+const RESOURCE_EMOJI: Record<string, string> = {
+  wood: "🪵",
+  stone: "🪨",
+  water: "💧",
+  food: "🌾",
+  metal: "⛓️",
+  fruit: "🍇"
+};
+
+const STATUS_LABEL: Record<AgentSummary["status"], string> = {
+  idle: "Idle",
+  moving: "Moving",
+  engaged: "Engaged",
+  recovering: "Recovering"
+};
+
+const LEGEND_ORDER: Array<{ terrain: keyof typeof TERRAIN_COLORS; label: string }> = [
+  { terrain: "FOREST", label: "Forest" },
+  { terrain: "GRASSLAND", label: "Grassland" },
+  { terrain: "PLAINS", label: "Plains" },
+  { terrain: "MOUNTAIN", label: "Mountain" },
+  { terrain: "DESERT", label: "Desert" },
+  { terrain: "SWAMP", label: "Swamp" },
+  { terrain: "TUNDRA", label: "Tundra" },
+  { terrain: "WATER", label: "Water" }
+];
+
+interface HoverState {
+  x: number;
+  y: number;
+  clientX: number;
+  clientY: number;
+  agent?: AgentSummary;
+}
 
 export function MapPanel(): JSX.Element {
   const currentTurn = useSimulationStore(selectCurrentTurn);
+  const agents = useSimulationStore(selectAgents);
+  const selectedAgentId = useSimulationStore(selectSelectedAgentId);
+  const selectedTile = useSimulationStore(selectSelectedTile);
+  const setSelectedAgent = useSimulationStore((state) => state.setSelectedAgent);
+  const setSelectedTile = useSimulationStore((state) => state.setSelectedTile);
 
-  const heatmapGrid = useMemo(() => {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const [hover, setHover] = useState<HoverState | null>(null);
+
+  const world = currentTurn?.world;
+
+  const heatmapLookup = useMemo(() => {
+    const map = new Map<string, number>();
     if (!currentTurn) {
-      return Array.from({ length: GRID_SIZE * GRID_SIZE }, () => 0);
+      return map;
     }
-    const base = Array.from({ length: GRID_SIZE * GRID_SIZE }, () => 0);
     for (const cell of currentTurn.heatmap) {
-      const index = cell.y * GRID_SIZE + cell.x;
-      if (index >= 0 && index < base.length) {
-        base[index] = cell.intensity;
-      }
+      map.set(makeTileKey(cell.x, cell.y), cell.intensity);
     }
-    return base;
+    return map;
   }, [currentTurn]);
 
+  const agentClusters = useMemo(() => {
+    const clusters = new Map<string, AgentSummary[]>();
+    for (const agent of agents) {
+      const key = makeTileKey(agent.location.x, agent.location.y);
+      const existing = clusters.get(key) ?? [];
+      existing.push(agent);
+      existing.sort((a, b) => a.id.localeCompare(b.id));
+      clusters.set(key, existing);
+    }
+    return clusters;
+  }, [agents]);
+
+  const selectedAgent = useMemo(
+    () => agents.find((agent) => agent.id === selectedAgentId) ?? null,
+    [agents, selectedAgentId]
+  );
+
+  const roster = useMemo(() => {
+    return [...agents].sort((a, b) => {
+      if (a.faction !== b.faction) {
+        return a.faction.localeCompare(b.faction);
+      }
+      return b.morale - a.morale;
+    });
+  }, [agents]);
+
+  useEffect(() => {
+    if (!world) {
+      return;
+    }
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const context = canvas.getContext("2d");
+    if (!context) {
+      return;
+    }
+
+    const pixelRatio = window.devicePixelRatio || 1;
+    const mapSize = world.size * TILE_SIZE;
+    canvas.width = mapSize * pixelRatio;
+    canvas.height = mapSize * pixelRatio;
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+
+    context.save();
+    context.scale(pixelRatio, pixelRatio);
+    context.clearRect(0, 0, mapSize, mapSize);
+    context.fillStyle = "#05070f";
+    context.fillRect(0, 0, mapSize, mapSize);
+
+    for (let y = 0; y < world.size; y += 1) {
+      for (let x = 0; x < world.size; x += 1) {
+        const index = y * world.size + x;
+        const terrain = world.terrain[index];
+        const color = TERRAIN_COLORS[terrain] ?? TERRAIN_COLORS.DEFAULT;
+        const originX = x * TILE_SIZE;
+        const originY = y * TILE_SIZE;
+
+        context.fillStyle = color;
+        context.fillRect(originX, originY, TILE_SIZE, TILE_SIZE);
+
+        context.fillStyle = "rgba(255, 255, 255, 0.08)";
+        context.fillRect(originX, originY, TILE_SIZE, TILE_SIZE * 0.35);
+        context.fillStyle = "rgba(0, 0, 0, 0.28)";
+        context.fillRect(originX, originY + TILE_SIZE * 0.65, TILE_SIZE, TILE_SIZE * 0.35);
+
+        const intensity = heatmapLookup.get(makeTileKey(x, y)) ?? 0;
+        if (intensity > 0.01) {
+          context.fillStyle = `rgba(255, 156, 94, ${0.2 + intensity * 0.55})`;
+          context.fillRect(originX, originY, TILE_SIZE, TILE_SIZE);
+        }
+
+        context.strokeStyle = "rgba(6, 9, 18, 0.7)";
+        context.strokeRect(originX, originY, TILE_SIZE, TILE_SIZE);
+      }
+    }
+
+    if (selectedTile && isTileInside(world, selectedTile)) {
+      context.lineWidth = 2;
+      context.strokeStyle = "rgba(123, 241, 168, 0.9)";
+      context.strokeRect(
+        selectedTile.x * TILE_SIZE + 1,
+        selectedTile.y * TILE_SIZE + 1,
+        TILE_SIZE - 2,
+        TILE_SIZE - 2
+      );
+    }
+
+    for (const [key, cluster] of agentClusters.entries()) {
+      const [tileX, tileY] = key.split(":").map(Number);
+      const baseX = tileX * TILE_SIZE;
+      const baseY = tileY * TILE_SIZE;
+
+      cluster.forEach((agent, index) => {
+        const markerSize = 6;
+        const offset = agentOffset(index, TILE_SIZE, markerSize);
+        const drawX = baseX + offset.x;
+        const drawY = baseY + offset.y;
+
+        if (agent.id === selectedAgentId) {
+          context.fillStyle = "rgba(0, 0, 0, 0.6)";
+          context.fillRect(drawX - 1, drawY - 1, markerSize + 2, markerSize + 2);
+          context.strokeStyle = "rgba(255, 255, 255, 0.9)";
+          context.strokeRect(drawX - 1, drawY - 1, markerSize + 2, markerSize + 2);
+        }
+
+        context.fillStyle = factionColor(agent.faction);
+        context.fillRect(drawX, drawY, markerSize, markerSize);
+        context.fillStyle = "rgba(0, 0, 0, 0.35)";
+        context.fillRect(drawX, drawY + markerSize - 2, markerSize, 2);
+      });
+    }
+
+    context.restore();
+  }, [world, heatmapLookup, agentClusters, selectedTile, selectedAgentId]);
+
+  useEffect(() => {
+    if (!selectedAgent || !world) {
+      return;
+    }
+    const { x, y } = selectedAgent.location;
+    if (!selectedTile || selectedTile.x !== x || selectedTile.y !== y) {
+      setSelectedTile({ x, y });
+    }
+  }, [selectedAgent, selectedTile, setSelectedTile, world]);
+
+  const handlePointerMove = (event: MouseEvent<HTMLCanvasElement>) => {
+    if (!world) {
+      setHover(null);
+      return;
+    }
+    const coords = translatePointer(event, canvasRef.current, world.size);
+    if (!coords) {
+      setHover(null);
+      return;
+    }
+    const key = makeTileKey(coords.x, coords.y);
+    const agent = agentClusters.get(key)?.[0];
+    setHover({ x: coords.x, y: coords.y, clientX: event.clientX, clientY: event.clientY, agent });
+  };
+
+  const handlePointerLeave = () => {
+    setHover(null);
+  };
+
+  const handleClick = (event: MouseEvent<HTMLCanvasElement>) => {
+    if (!world) {
+      return;
+    }
+    const coords = translatePointer(event, canvasRef.current, world.size);
+    if (!coords) {
+      return;
+    }
+    const key = makeTileKey(coords.x, coords.y);
+    const occupants = agentClusters.get(key);
+    setSelectedTile({ x: coords.x, y: coords.y });
+    if (occupants && occupants.length > 0) {
+      const chosen = occupants.find((candidate) => candidate.id === selectedAgentId) ?? occupants[0];
+      setSelectedAgent(chosen.id, chosen.location);
+    } else {
+      setSelectedAgent(null);
+    }
+  };
+
+  const tileKey = selectedTile ? makeTileKey(selectedTile.x, selectedTile.y) : null;
+  const tileIntensity = tileKey ? heatmapLookup.get(tileKey) ?? 0 : 0;
+  const tileAgents = tileKey ? agentClusters.get(tileKey) ?? [] : [];
+  const tileResources =
+    selectedTile && world
+      ? world.resources[selectedTile.y * world.size + selectedTile.x]
+      : undefined;
+  const tileTerrain =
+    selectedTile && world ? world.terrain[selectedTile.y * world.size + selectedTile.x] : undefined;
+
+  const resourceEntries = useMemo(() => {
+    if (!tileResources) {
+      return [] as Array<[string, number]>;
+    }
+    return Object.entries(tileResources).sort((a, b) => b[1] - a[1]);
+  }, [tileResources]);
+
+  const averageMorale = useMemo(() => {
+    if (agents.length === 0) {
+      return 0;
+    }
+    const total = agents.reduce((sum, agent) => sum + agent.morale, 0);
+    return Math.round(total / agents.length);
+  }, [agents]);
+
+  const hoverIntensity = hover ? heatmapLookup.get(makeTileKey(hover.x, hover.y)) ?? 0 : 0;
+
   return (
-    <div className="panel panel--map">
+    <div className="panel panel--map map-panel">
       <div className="panel__header">
         <div>
-          <h2>Spatial Overview</h2>
-          <p>Heatmap of morale and resource pressure for turn {currentTurn?.turnId ?? "—"}</p>
+          <h2>Spatial Ops Board</h2>
+          <p>Pixel terrain with live agent overlays and resource telemetry</p>
         </div>
-        <span className="panel__badge">{currentTurn ? formatTime(currentTurn.occurredAt) : "Awaiting stream"}</span>
+        <span className="panel__badge">
+          {currentTurn ? formatTime(currentTurn.occurredAt) : "Awaiting stream"}
+        </span>
       </div>
-      <div className="map-grid" role="presentation">
-        {heatmapGrid.map((intensity, idx) => {
-          const hue = 180 - intensity * 120;
-          const alpha = 0.12 + intensity * 0.85;
-          return <div key={idx} style={{ backgroundColor: `hsla(${hue}, 90%, 55%, ${alpha})` }} />;
-        })}
+      <div className="map-panel__content">
+        <div className="map-panel__canvas-wrapper">
+          {world ? (
+            <>
+              <div className="map-panel__canvas-surface">
+                <canvas
+                  ref={canvasRef}
+                  className="map-panel__canvas"
+                  role="presentation"
+                  onClick={handleClick}
+                  onMouseMove={handlePointerMove}
+                  onMouseLeave={handlePointerLeave}
+                />
+              </div>
+              <Legend />
+              {hover && (
+                <Tooltip
+                  hover={hover}
+                  world={world}
+                  resources={world.resources[hover.y * world.size + hover.x]}
+                  intensity={hoverIntensity}
+                />
+              )}
+            </>
+          ) : (
+            <div className="map-panel__empty">Awaiting telemetry…</div>
+          )}
+        </div>
+        <aside className="map-panel__sidebar">
+          <section className="map-panel__summary">
+            <h3>Tile Focus</h3>
+            {selectedTile && world ? (
+              <>
+                <p>
+                  ({selectedTile.x}, {selectedTile.y}) — {formatTerrain(tileTerrain)}
+                </p>
+                <div className="map-panel__summary-grid">
+                  <span>Pressure</span>
+                  <strong>{Math.round(tileIntensity * 100)}</strong>
+                  <span>Occupants</span>
+                  <strong>{tileAgents.length}</strong>
+                </div>
+                {resourceEntries.length > 0 ? (
+                  <div className="map-panel__resource-list">
+                    {resourceEntries.map(([resource, value]) => (
+                      <span key={resource} className="map-panel__resource-tag">
+                        <span className="map-panel__resource-icon">{RESOURCE_EMOJI[resource] ?? ""}</span>
+                        {formatResource(resource)} {value}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="map-panel__muted">No stored resources</p>
+                )}
+                {tileAgents.length > 0 && (
+                  <div className="map-panel__tile-agents">
+                    {tileAgents.map((agent) => (
+                      <button
+                        key={agent.id}
+                        type="button"
+                        className="map-panel__tile-agent-pill"
+                        onClick={() => setSelectedAgent(agent.id, agent.location)}
+                      >
+                        {agent.name}
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </>
+            ) : (
+              <p className="map-panel__muted">Select a tile or agent to inspect terrain and inventories.</p>
+            )}
+          </section>
+          <section className="map-panel__summary">
+            <h3>Agent Spotlight</h3>
+            {selectedAgent ? (
+              <>
+                <p>
+                  {selectedAgent.name} — {selectedAgent.role}
+                </p>
+                <div className="map-panel__summary-grid">
+                  <span>Faction</span>
+                  <strong>{selectedAgent.faction}</strong>
+                  <span>Status</span>
+                  <strong>{STATUS_LABEL[selectedAgent.status]}</strong>
+                  <span>Morale</span>
+                  <strong>{Math.round(selectedAgent.morale)}</strong>
+                  <span>Stores</span>
+                  <strong>{Math.round(selectedAgent.resources)}</strong>
+                </div>
+                <p className="map-panel__muted">
+                  Position ({selectedAgent.location.x}, {selectedAgent.location.y})
+                </p>
+              </>
+            ) : (
+              <p className="map-panel__muted">Choose an agent from the roster to see detailed telemetry.</p>
+            )}
+          </section>
+          <section className="map-panel__roster">
+            <header>
+              <h3>Agent Roster</h3>
+              <span>{agents.length}</span>
+            </header>
+            <div className="map-panel__agent-list">
+              {roster.map((agent) => (
+                <button
+                  key={agent.id}
+                  type="button"
+                  className={classNames(
+                    "map-panel__agent",
+                    agent.id === selectedAgentId && "map-panel__agent--selected"
+                  )}
+                  onClick={() => setSelectedAgent(agent.id, agent.location)}
+                >
+                  <div className="map-panel__agent-title">
+                    <span className="map-panel__agent-name">
+                      <span
+                        className="map-panel__agent-faction"
+                        style={{ backgroundColor: factionColor(agent.faction) }}
+                        aria-hidden
+                      />
+                      {agent.name}
+                    </span>
+                    <span className={classNames("map-panel__agent-status", `map-panel__agent-status--${agent.status}`)}>
+                      {STATUS_LABEL[agent.status]}
+                    </span>
+                  </div>
+                  <div className="map-panel__agent-meta">
+                    <span>Morale {Math.round(agent.morale)}</span>
+                    <span>Stores {Math.round(agent.resources)}</span>
+                  </div>
+                  <div className="map-panel__agent-traits">
+                    <span>{agent.role}</span>
+                    <span>
+                      ({agent.location.x}, {agent.location.y})
+                    </span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          </section>
+        </aside>
       </div>
       <footer className="panel__footer">
         <div className="panel__footer-metric">
           <span className="label">Live Agents</span>
-          <strong>{currentTurn?.agents.length ?? 0}</strong>
+          <strong>{agents.length}</strong>
         </div>
         <div className="panel__footer-metric">
           <span className="label">Critical Alerts</span>
-          <strong>
-            {currentTurn?.events.filter((event) => event.severity === "critical").length ?? 0}
-          </strong>
+          <strong>{currentTurn?.events.filter((event) => event.severity === "critical").length ?? 0}</strong>
+        </div>
+        <div className="panel__footer-metric">
+          <span className="label">Avg Morale</span>
+          <strong>{averageMorale}</strong>
         </div>
         <div className="panel__footer-metric">
           <span className="label">Latency</span>
@@ -57,7 +452,141 @@ export function MapPanel(): JSX.Element {
   );
 }
 
+function makeTileKey(x: number, y: number): string {
+  return `${x}:${y}`;
+}
+
+function translatePointer(
+  event: MouseEvent<HTMLCanvasElement>,
+  canvas: HTMLCanvasElement | null,
+  worldSize: number
+): { x: number; y: number } | null {
+  if (!canvas) {
+    return null;
+  }
+  const rect = canvas.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    return null;
+  }
+  const pixelRatio = window.devicePixelRatio || 1;
+  const scaleX = canvas.width / rect.width;
+  const scaleY = canvas.height / rect.height;
+  const canvasX = ((event.clientX - rect.left) * scaleX) / pixelRatio;
+  const canvasY = ((event.clientY - rect.top) * scaleY) / pixelRatio;
+  const tileX = Math.floor(canvasX / TILE_SIZE);
+  const tileY = Math.floor(canvasY / TILE_SIZE);
+  if (tileX < 0 || tileY < 0 || tileX >= worldSize || tileY >= worldSize) {
+    return null;
+  }
+  return { x: tileX, y: tileY };
+}
+
+function agentOffset(index: number, tileSize: number, markerSize: number): { x: number; y: number } {
+  const center = (tileSize - markerSize) / 2;
+  const offsets = [
+    { x: center, y: center },
+    { x: 2, y: 2 },
+    { x: tileSize - markerSize - 2, y: 2 },
+    { x: 2, y: tileSize - markerSize - 2 },
+    { x: tileSize - markerSize - 2, y: tileSize - markerSize - 2 }
+  ];
+  return offsets[index % offsets.length];
+}
+
+function factionColor(faction: string): string {
+  if (faction.toLowerCase().includes("aur")) {
+    return "#7bf1a8";
+  }
+  if (faction.toLowerCase().includes("horizon")) {
+    return "#58c6ff";
+  }
+  if (faction.toLowerCase().includes("zephyr")) {
+    return "#f5a97f";
+  }
+  return "#c1c9ff";
+}
+
+function classNames(...values: Array<string | false | null | undefined>): string {
+  return values.filter(Boolean).join(" ");
+}
+
+function formatResource(key: string): string {
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+function formatTerrain(terrain?: string): string {
+  if (!terrain) {
+    return "Unknown";
+  }
+  return terrain.charAt(0) + terrain.slice(1).toLowerCase();
+}
+
 function formatTime(value: string): string {
   const date = new Date(value);
   return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
+}
+
+function isTileInside(world: WorldState, tile: { x: number; y: number }): boolean {
+  return tile.x >= 0 && tile.y >= 0 && tile.x < world.size && tile.y < world.size;
+}
+
+function Legend(): JSX.Element {
+  return (
+    <div className="map-panel__legend">
+      {LEGEND_ORDER.map(({ terrain, label }) => (
+        <span key={terrain} className="map-panel__legend-item">
+          <span
+            className="map-panel__legend-swatch"
+            style={{ backgroundColor: TERRAIN_COLORS[terrain] ?? TERRAIN_COLORS.DEFAULT }}
+          />
+          {label}
+        </span>
+      ))}
+      <span className="map-panel__legend-item">
+        <span className="map-panel__legend-swatch" style={{ backgroundColor: "#ff9c5e" }} /> Pressure
+      </span>
+    </div>
+  );
+}
+
+function Tooltip({
+  hover,
+  world,
+  resources,
+  intensity
+}: {
+  hover: HoverState;
+  world: WorldState;
+  resources: TileResources | undefined;
+  intensity: number;
+}): JSX.Element {
+  const index = hover.y * world.size + hover.x;
+  const terrain = world.terrain[index];
+  const entries = resources ? Object.entries(resources).sort((a, b) => b[1] - a[1]).slice(0, 4) : [];
+
+  return (
+    <div className="map-panel__tooltip" style={{ left: hover.clientX, top: hover.clientY }}>
+      <strong>
+        Tile ({hover.x}, {hover.y})
+      </strong>
+      <p>{formatTerrain(terrain)}</p>
+      <p className="map-panel__tooltip-metric">Pressure {Math.round(intensity * 100)}</p>
+      {hover.agent && (
+        <p className="map-panel__tooltip-agent">
+          {hover.agent.name} — {STATUS_LABEL[hover.agent.status]}
+        </p>
+      )}
+      {entries.length > 0 ? (
+        <ul>
+          {entries.map(([resource, value]) => (
+            <li key={resource}>
+              {RESOURCE_EMOJI[resource] ?? ""} {formatResource(resource)} {value}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="map-panel__tooltip-empty">No notable resources</p>
+      )}
+    </div>
+  );
 }

--- a/web_ui/monitor/src/services/mockTurnStream.ts
+++ b/web_ui/monitor/src/services/mockTurnStream.ts
@@ -3,8 +3,10 @@ import type {
   CohortMetric,
   ConnectionState,
   InteractionRecord,
+  TileResources,
   TimelineEvent,
-  TurnPayload
+  TurnPayload,
+  WorldState
 } from "../types/simulation";
 
 interface Subscriber {
@@ -12,10 +14,23 @@ interface Subscriber {
   onConnectionUpdate?: (connection: Partial<ConnectionState>) => void;
 }
 
+const STATUS_SEQUENCE: AgentSummary["status"][] = ["moving", "engaged", "recovering", "idle"];
+const ROLES = ["Scout", "Diplomat", "Strategist", "Mediator"] as const;
+const FACTIONS = ["Aurora", "Horizon", "Zephyr"] as const;
+
 export class MockTurnStream {
   private subscribers = new Set<Subscriber>();
   private tickHandle: number | null = null;
   private turnId = 0;
+  private readonly worldSize = 32;
+  private readonly terrain: WorldState["terrain"];
+  private readonly baseResources: TileResources[];
+
+  constructor() {
+    const baseWorld = this.generateWorld();
+    this.terrain = baseWorld.terrain;
+    this.baseResources = baseWorld.resources;
+  }
 
   subscribe(subscriber: Subscriber): () => void {
     this.subscribers.add(subscriber);
@@ -61,7 +76,8 @@ export class MockTurnStream {
       agents: this.generateAgents(),
       cohorts: this.generateCohorts(),
       heatmap: this.generateHeatmap(),
-      interactions: this.generateInteractions(this.turnId, now)
+      interactions: this.generateInteractions(this.turnId, now),
+      world: this.buildWorldSnapshot()
     };
 
     for (const subscriber of this.subscribers) {
@@ -110,19 +126,28 @@ export class MockTurnStream {
   }
 
   private generateAgents(): AgentSummary[] {
-    return Array.from({ length: 42 }, (_, idx) => ({
-      id: `A-${idx.toString().padStart(2, "0")}`,
-      name: `Agent ${idx}`,
-      faction: idx % 2 === 0 ? "Aurora" : "Horizon",
-      role: idx % 3 === 0 ? "Scout" : "Diplomat",
-      morale: 50 + Math.sin((this.turnId + idx) / 3) * 30,
-      resources: 100 + Math.cos((this.turnId + idx) / 5) * 40,
-      location: {
-        x: Math.floor(Math.random() * 20),
-        y: Math.floor(Math.random() * 20)
-      },
-      status: (idx % 5 === 0 ? "engaged" : "moving") as AgentSummary["status"]
-    }));
+    return Array.from({ length: 48 }, (_, idx) => {
+      const faction = FACTIONS[idx % FACTIONS.length];
+      const role = ROLES[idx % ROLES.length];
+      const status = STATUS_SEQUENCE[(idx + this.turnId) % STATUS_SEQUENCE.length];
+      const morale = clamp(52 + Math.sin((this.turnId + idx) / 2.8) * 32, 20, 98);
+      const stores = clamp(88 + Math.cos((this.turnId + idx * 1.3) / 4.6) * 38, 30, 140);
+      const wanderX = Math.sin((this.turnId + idx * 1.7) / 3.2) * 0.5 + 0.5;
+      const wanderY = Math.cos((this.turnId * 0.8 + idx * 1.1) / 3.4) * 0.5 + 0.5;
+      const x = clamp(Math.floor(wanderX * (this.worldSize - 1)), 0, this.worldSize - 1);
+      const y = clamp(Math.floor(wanderY * (this.worldSize - 1)), 0, this.worldSize - 1);
+
+      return {
+        id: `A-${idx.toString().padStart(2, "0")}`,
+        name: `Agent ${idx}`,
+        faction,
+        role,
+        morale,
+        resources: stores,
+        location: { x, y },
+        status
+      };
+    });
   }
 
   private generateCohorts(): CohortMetric[] {
@@ -140,6 +165,12 @@ export class MockTurnStream {
         unit: "morale index"
       },
       {
+        name: "Zephyr Compact",
+        value: 58 + Math.sin(this.turnId / 1.7) * 5,
+        trend: Math.random() > 0.55 ? "up" : "down",
+        unit: "influence"
+      },
+      {
         name: "Logistics",
         value: 48 + Math.sin(this.turnId / 1.5) * 8,
         trend: Math.random() > 0.55 ? "up" : "down",
@@ -148,12 +179,20 @@ export class MockTurnStream {
     ];
   }
 
-  private generateHeatmap() {
-    return Array.from({ length: 60 }, () => ({
-      x: Math.floor(Math.random() * 20),
-      y: Math.floor(Math.random() * 20),
-      intensity: Math.random()
-    }));
+  private generateHeatmap(): TurnPayload["heatmap"] {
+    const cells: TurnPayload["heatmap"] = [];
+    for (let y = 0; y < this.worldSize; y += 1) {
+      for (let x = 0; x < this.worldSize; x += 1) {
+        const idx = y * this.worldSize + x;
+        const base = (Math.sin((this.turnId + x * 3 + y * 2) / 5) + 1) / 2;
+        const resourceBias = (this.baseResources[idx]?.food ?? 0) / 16;
+        const intensity = clamp(base * 0.6 + resourceBias * 0.5, 0, 1);
+        if (intensity > 0.08) {
+          cells.push({ x, y, intensity });
+        }
+      }
+    }
+    return cells;
   }
 
   private generateInteractions(turnId: number, now: Date): InteractionRecord[] {
@@ -192,6 +231,120 @@ export class MockTurnStream {
 
     return records;
   }
+
+  private generateWorld(): WorldState {
+    const terrain: WorldState["terrain"] = [];
+    const resources: TileResources[] = [];
+
+    for (let y = 0; y < this.worldSize; y += 1) {
+      for (let x = 0; x < this.worldSize; x += 1) {
+        const elevation = Math.sin(x * 0.27) + Math.cos(y * 0.19);
+        const moisture = Math.sin((x + y) * 0.14) + Math.cos((x - y) * 0.11) * 0.6;
+        const rim = Math.min(x, y, this.worldSize - 1 - x, this.worldSize - 1 - y);
+
+        let terrainType: string;
+        if (rim < 2 || elevation < -1.2) {
+          terrainType = "WATER";
+        } else if (elevation > 1.2) {
+          terrainType = "MOUNTAIN";
+        } else if (elevation > 0.8) {
+          terrainType = moisture > 0.3 ? "FOREST" : "GRASSLAND";
+        } else if (moisture > 1) {
+          terrainType = "SWAMP";
+        } else if (moisture < -1) {
+          terrainType = "DESERT";
+        } else if (moisture < -0.2) {
+          terrainType = "PLAINS";
+        } else if (elevation < -0.6) {
+          terrainType = "TUNDRA";
+        } else {
+          terrainType = "GRASSLAND";
+        }
+
+        terrain.push(terrainType);
+        resources.push(this.seedResources(terrainType, x, y));
+      }
+    }
+
+    return { size: this.worldSize, terrain, resources };
+  }
+
+  private seedResources(terrain: string, x: number, y: number): TileResources {
+    const tile: TileResources = {};
+    const noise = Math.sin((x + 13) * 0.45) + Math.cos((y + 7) * 0.32);
+
+    const allocate = (type: keyof TileResources, base: number, variance: number) => {
+      const value = Math.max(0, Math.round(base + noise * variance));
+      if (value > 0) {
+        tile[type] = value;
+      }
+    };
+
+    switch (terrain) {
+      case "FOREST":
+        allocate("wood", 8, 3);
+        allocate("fruit", 3, 2);
+        allocate("food", 2, 2);
+        break;
+      case "MOUNTAIN":
+        allocate("stone", 7, 3);
+        allocate("metal", 5, 2);
+        break;
+      case "WATER":
+        allocate("water", 10, 3);
+        allocate("food", 2, 2);
+        break;
+      case "PLAINS":
+        allocate("food", 5, 3);
+        allocate("wood", 2, 2);
+        break;
+      case "DESERT":
+        allocate("stone", 3, 2);
+        allocate("metal", 2, 2);
+        break;
+      case "SWAMP":
+        allocate("water", 6, 2);
+        allocate("food", 3, 2);
+        break;
+      case "TUNDRA":
+        allocate("stone", 2, 1);
+        allocate("food", 1, 1);
+        break;
+      default:
+        allocate("food", 4, 2);
+        allocate("wood", 3, 2);
+        break;
+    }
+
+    return tile;
+  }
+
+  private buildWorldSnapshot(): WorldState {
+    const resources = this.baseResources.map((tile, idx) => {
+      const x = idx % this.worldSize;
+      const y = Math.floor(idx / this.worldSize);
+      const seasonal = 1 + Math.sin((this.turnId + x * 2 + y) / 8) * 0.18;
+      const supplyShock = 1 + Math.cos((this.turnId + x + y * 2) / 11) * 0.12;
+      const next: TileResources = {};
+      for (const [key, value] of Object.entries(tile)) {
+        const amount = Math.max(0, Math.round(value * seasonal * supplyShock));
+        if (amount > 0) {
+          next[key] = amount;
+        }
+      }
+      return next;
+    });
+
+    return {
+      size: this.worldSize,
+      terrain: this.terrain,
+      resources
+    };
+  }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
 }
 
 function cryptoRandomId(): string {

--- a/web_ui/monitor/src/state/store.test.ts
+++ b/web_ui/monitor/src/state/store.test.ts
@@ -12,7 +12,12 @@ const baseTurn: TurnPayload = {
   agents: [],
   cohorts: [],
   heatmap: [],
-  interactions: []
+  interactions: [],
+  world: {
+    size: 4,
+    terrain: Array.from({ length: 16 }, () => "PLAINS"),
+    resources: Array.from({ length: 16 }, () => ({}))
+  }
 };
 
 describe("useSimulationStore", () => {

--- a/web_ui/monitor/src/styles/map-panel.css
+++ b/web_ui/monitor/src/styles/map-panel.css
@@ -1,0 +1,371 @@
+.map-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+}
+
+.map-panel__content {
+  display: grid;
+  grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
+  gap: 1.25rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.map-panel__canvas-wrapper {
+  position: relative;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 20px;
+  padding: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.02), 0 18px 48px rgba(5, 9, 18, 0.35);
+  display: flex;
+  align-items: stretch;
+  min-height: 0;
+}
+
+.map-panel__canvas-surface {
+  position: relative;
+  width: 100%;
+}
+
+.map-panel__canvas-surface::before {
+  content: "";
+  display: block;
+  padding-top: 100%;
+}
+
+.map-panel__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  image-rendering: pixelated;
+  border-radius: 14px;
+  background: #05070f;
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+  cursor: pointer;
+}
+
+.map-panel__legend {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.4rem 0.75rem;
+  padding: 0.65rem 0.85rem;
+  background: rgba(7, 11, 20, 0.88);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  font-size: 0.75rem;
+  line-height: 1.1;
+  box-shadow: 0 12px 24px rgba(5, 9, 18, 0.4);
+}
+
+.map-panel__legend-item {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.map-panel__legend-swatch {
+  width: 14px;
+  height: 14px;
+  border-radius: 4px;
+  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.5);
+}
+
+.map-panel__tooltip {
+  position: fixed;
+  pointer-events: none;
+  transform: translate(14px, 14px);
+  background: rgba(7, 11, 20, 0.94);
+  border: 1px solid rgba(123, 241, 168, 0.45);
+  border-radius: 12px;
+  padding: 0.7rem 0.85rem;
+  font-size: 0.78rem;
+  line-height: 1.3;
+  color: var(--text-primary);
+  z-index: 40;
+  min-width: 180px;
+  box-shadow: 0 16px 32px rgba(5, 9, 18, 0.55);
+}
+
+.map-panel__tooltip p {
+  margin: 0.35rem 0;
+}
+
+.map-panel__tooltip ul {
+  margin: 0.35rem 0 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.map-panel__tooltip-metric {
+  font-weight: 600;
+  color: var(--accent-strong);
+}
+
+.map-panel__tooltip-agent {
+  font-weight: 500;
+}
+
+.map-panel__tooltip-empty {
+  color: var(--text-secondary);
+  margin: 0;
+}
+
+.map-panel__sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  min-height: 0;
+}
+
+.map-panel__summary {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 0.9rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+  min-height: 0;
+}
+
+.map-panel__summary h3 {
+  margin: 0;
+  font-size: 0.92rem;
+}
+
+.map-panel__summary p {
+  margin: 0;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__summary-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.35rem 0.75rem;
+  font-size: 0.8rem;
+}
+
+.map-panel__summary-grid span {
+  color: var(--text-secondary);
+}
+
+.map-panel__summary-grid strong {
+  font-size: 0.9rem;
+}
+
+.map-panel__resource-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.map-panel__resource-tag {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(123, 241, 168, 0.14);
+  border: 1px solid rgba(123, 241, 168, 0.24);
+  font-size: 0.74rem;
+}
+
+.map-panel__resource-icon {
+  font-size: 0.85rem;
+}
+
+.map-panel__muted {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  margin: 0;
+}
+
+.map-panel__tile-agents {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.map-panel__tile-agent-pill {
+  border: 1px solid rgba(88, 198, 255, 0.35);
+  background: rgba(88, 198, 255, 0.12);
+  color: var(--text-primary);
+  border-radius: 999px;
+  padding: 0.3rem 0.65rem;
+  font-size: 0.74rem;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.map-panel__tile-agent-pill:hover {
+  transform: translateY(-1px);
+  border-color: rgba(123, 241, 168, 0.5);
+}
+
+.map-panel__roster {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 0.95rem 1rem;
+}
+
+.map-panel__roster header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__roster h3 {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+}
+
+.map-panel__agent-list {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.55rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.map-panel__agent {
+  border: 1px solid transparent;
+  background: rgba(255, 255, 255, 0.05);
+  color: inherit;
+  border-radius: 14px;
+  padding: 0.65rem 0.8rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  text-align: left;
+  cursor: pointer;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.map-panel__agent:hover {
+  transform: translateY(-2px);
+  border-color: rgba(123, 241, 168, 0.45);
+}
+
+.map-panel__agent--selected {
+  background: rgba(123, 241, 168, 0.18);
+  border-color: rgba(123, 241, 168, 0.6);
+}
+
+.map-panel__agent-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.map-panel__agent-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.86rem;
+}
+
+.map-panel__agent-faction {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.4);
+}
+
+.map-panel__agent-status {
+  padding: 0.2rem 0.6rem;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(88, 198, 255, 0.35);
+  background: rgba(88, 198, 255, 0.18);
+}
+
+.map-panel__agent-status--engaged {
+  border-color: rgba(255, 123, 123, 0.4);
+  background: rgba(255, 123, 123, 0.2);
+}
+
+.map-panel__agent-status--moving {
+  border-color: rgba(123, 241, 168, 0.4);
+  background: rgba(123, 241, 168, 0.18);
+}
+
+.map-panel__agent-status--recovering {
+  border-color: rgba(255, 198, 107, 0.45);
+  background: rgba(255, 198, 107, 0.2);
+}
+
+.map-panel__agent-status--idle {
+  border-color: rgba(255, 255, 255, 0.2);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.map-panel__agent-meta {
+  display: flex;
+  gap: 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__agent-traits {
+  display: flex;
+  gap: 0.6rem;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--border-subtle);
+  border-radius: 14px;
+  color: var(--text-secondary);
+  font-size: 0.85rem;
+}
+
+@media (max-width: 1400px) {
+  .map-panel__content {
+    grid-template-columns: 1fr;
+  }
+
+  .map-panel__canvas-wrapper {
+    min-height: 420px;
+  }
+}
+
+@media (max-width: 900px) {
+  .map-panel__canvas-wrapper {
+    padding: 0.75rem;
+  }
+
+  .map-panel__legend {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    font-size: 0.7rem;
+  }
+}

--- a/web_ui/monitor/src/styles/panel.css
+++ b/web_ui/monitor/src/styles/panel.css
@@ -63,17 +63,3 @@
   letter-spacing: 0.08em;
 }
 
-.map-grid {
-  display: grid;
-  grid-template-columns: repeat(20, minmax(0, 1fr));
-  grid-template-rows: repeat(20, minmax(0, 1fr));
-  gap: 1px;
-  background: rgba(255, 255, 255, 0.03);
-  border-radius: 12px;
-  overflow: hidden;
-  min-height: 240px;
-}
-
-.map-grid div {
-  transition: background-color 0.35s ease;
-}

--- a/web_ui/monitor/src/types/simulation.ts
+++ b/web_ui/monitor/src/types/simulation.ts
@@ -27,6 +27,16 @@ export interface HeatmapCell {
   intensity: number;
 }
 
+export interface TileResources {
+  [resource: string]: number;
+}
+
+export interface WorldState {
+  size: number;
+  terrain: string[];
+  resources: TileResources[];
+}
+
 export interface TimelineEvent {
   id: string;
   turnId: number;
@@ -57,6 +67,7 @@ export interface TurnPayload {
   cohorts: CohortMetric[];
   heatmap: HeatmapCell[];
   interactions: InteractionRecord[];
+  world: WorldState;
 }
 
 export interface ConnectionState {


### PR DESCRIPTION
## Summary
- replace the monitor heatmap with an interactive pixel-map canvas that mirrors the legacy web UI features and adds tile, agent, and resource inspectors
- extend the mock turn stream, types, and store state so turns include world terrain/resources, selection state, and roster data for the new dashboard
- add dedicated styling for the merged layout and agent roster while cleaning up obsolete grid styles

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e48c1cfffc83268f20aa5877950bd2