### PR TITLE
feat: hydrate monitor from structured api snapshot

### DIFF
--- a/web_ui/monitor/src/App.tsx
+++ b/web_ui/monitor/src/App.tsx
@@ -9,8 +9,10 @@ import { ConnectionBanner } from "./components/controls/ConnectionBanner";
 import { useMonitorStream } from "./services/monitorStream";
 import { RunControls } from "./components/controls/RunControls";
 import { MessageBox } from "./components/messages/MessageBox";
+import { useSimulationBootstrap } from "./hooks/useSimulationBootstrap";
 
 function App(): JSX.Element {
+  useSimulationBootstrap();
   useMonitorStream();
 
   return (

--- a/web_ui/monitor/src/hooks/useSimulationBootstrap.ts
+++ b/web_ui/monitor/src/hooks/useSimulationBootstrap.ts
@@ -1,0 +1,61 @@
+import { useEffect } from "react";
+import { fetchSimulationSnapshot } from "../services/monitorApi";
+import {
+  buildAgentActionMap,
+  mapSnapshotToTurnPayload,
+  normalizeLogEntries
+} from "../services/transformers";
+import { useSimulationStore } from "../state/store";
+import type { Structure } from "../types/simulation";
+
+const SNAPSHOT_REFRESH_INTERVAL_MS = 15000;
+
+export function useSimulationBootstrap(): void {
+  const ingestTurn = useSimulationStore((s) => s.ingestTurn);
+  const setAgentActions = useSimulationStore((s) => s.setAgentActions);
+  const setStructures = useSimulationStore((s) => s.setStructures);
+  const replaceLogs = useSimulationStore((s) => s.replaceLogs);
+
+  useEffect(() => {
+    let cancelled = false;
+    let timer: number | null = null;
+
+    async function hydrateFromSnapshot(): Promise<void> {
+      try {
+        const snapshot = await fetchSimulationSnapshot();
+        if (cancelled || !snapshot) {
+          return;
+        }
+        const turn = mapSnapshotToTurnPayload(snapshot);
+        if (turn) {
+          const state = useSimulationStore.getState();
+          const last = state.turns[state.turns.length - 1];
+          if (!last || last.hash !== turn.hash) {
+            ingestTurn(turn);
+          }
+          setAgentActions(buildAgentActionMap(turn.agents));
+        }
+        if (Array.isArray(snapshot.structures)) {
+          setStructures(snapshot.structures as Structure[]);
+        }
+        if (Array.isArray(snapshot.logs)) {
+          const entries = normalizeLogEntries(snapshot.logs).slice(-200);
+          replaceLogs(entries);
+        }
+      } catch {
+        // ignore fetch errors; websocket stream will continue to drive UI
+      }
+    }
+
+    hydrateFromSnapshot();
+
+    timer = window.setInterval(hydrateFromSnapshot, SNAPSHOT_REFRESH_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (timer !== null) {
+        window.clearInterval(timer);
+      }
+    };
+  }, [ingestTurn, replaceLogs, setAgentActions, setStructures]);
+}

--- a/web_ui/monitor/src/services/monitorApi.ts
+++ b/web_ui/monitor/src/services/monitorApi.ts
@@ -7,6 +7,29 @@ export interface StartPayload {
   overrides?: string[];
 }
 
+export interface SimulationSnapshot {
+  world?: unknown;
+  agents?: unknown[];
+  turn?: number;
+  timestamp?: number;
+  occurred_at?: string;
+  logs?: unknown[];
+  actions?: unknown[];
+  structures?: unknown[];
+  events?: unknown[];
+  heatmap?: unknown[];
+  interactions?: unknown[];
+  cohorts?: unknown[];
+}
+
+async function get<T>(url: string): Promise<T> {
+  const resp = await fetch(url, { method: "GET" });
+  if (!resp.ok) {
+    throw new Error(`${resp.status}`);
+  }
+  return (await resp.json()) as T;
+}
+
 async function post<T>(url: string, body: unknown): Promise<T> {
   const resp = await fetch(url, {
     method: "POST",
@@ -32,6 +55,15 @@ export async function startSimulation(payload: StartPayload): Promise<void> {
 
 export async function stopSimulation(): Promise<void> {
   await post("/api/simulation/stop", {});
+}
+
+export async function fetchSimulationSnapshot(): Promise<SimulationSnapshot | null> {
+  try {
+    const data = await get<{ world?: unknown } & SimulationSnapshot>("/api/simulation-data");
+    return data ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export async function trinityBroadcast(content: string, targets?: number[]): Promise<void> {

--- a/web_ui/monitor/src/services/transformers.ts
+++ b/web_ui/monitor/src/services/transformers.ts
@@ -1,0 +1,250 @@
+import type {
+  AgentSummary,
+  InteractionRecord,
+  TurnPayload,
+  WorldGroupSummary,
+  WorldState,
+  WorldStats
+} from "../types/simulation";
+
+const STATUS_NAMES: Record<AgentSummary["status"], string> = {
+  idle: "Idle",
+  moving: "On the move",
+  engaged: "Engaged",
+  recovering: "Recovering"
+};
+
+function safeNumber(value: unknown, fallback = 0): number {
+  const num = typeof value === "string" ? Number(value) : value;
+  return typeof num === "number" && Number.isFinite(num) ? num : fallback;
+}
+
+function safeString(value: unknown, fallback = ""): string {
+  if (typeof value === "string") {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return fallback;
+}
+
+function mapWorldStats(stats: any): WorldStats | undefined {
+  if (!stats || typeof stats !== "object") {
+    return undefined;
+  }
+  return {
+    total_agents: safeNumber(stats.total_agents ?? stats.totalAgents ?? stats.agents),
+    active_agents: safeNumber(stats.active_agents ?? stats.activeAgents ?? stats.active),
+    total_groups: safeNumber(stats.total_groups ?? stats.groups),
+    total_resources: safeNumber(stats.total_resources ?? stats.resources),
+    technologies_discovered: safeNumber(stats.technologies_discovered ?? stats.tech)
+  };
+}
+
+function mapWorldGroups(groups: any): WorldGroupSummary[] | undefined {
+  if (!Array.isArray(groups)) {
+    return undefined;
+  }
+  return groups
+    .map((group) => ({
+      id: safeString(group.id ?? group.group_id ?? group.name ?? "group"),
+      name: safeString(group.name ?? group.id ?? "Group"),
+      member_count: safeNumber(group.member_count ?? group.members ?? group.memberCount),
+      reputation: safeNumber(group.reputation),
+      type: safeString(group.type ?? group.group_type ?? "unknown"),
+      leader: group.leader ?? null
+    }))
+    .sort((a, b) => b.member_count - a.member_count);
+}
+
+export function mapSnapshotToTurnPayload(snapshot: any): TurnPayload | null {
+  if (!snapshot || typeof snapshot !== "object" || !snapshot.world) {
+    return null;
+  }
+
+  const worldPayload = snapshot.world ?? {};
+
+  const worldTurnSource = worldPayload.turn ?? snapshot.turn;
+  const worldTurn =
+    typeof worldTurnSource === "number" || typeof worldTurnSource === "string"
+      ? safeNumber(worldTurnSource)
+      : undefined;
+
+  const world: WorldState = {
+    size: safeNumber(worldPayload.size),
+    terrain: Array.isArray(worldPayload.terrain) ? worldPayload.terrain : [],
+    resources: Array.isArray(worldPayload.resources) ? worldPayload.resources : [],
+    era: typeof worldPayload.era === "string" ? worldPayload.era : undefined,
+    turn: worldTurn,
+    stats: mapWorldStats(worldPayload.stats),
+    groups: mapWorldGroups(worldPayload.groups)
+  };
+
+  const agents: AgentSummary[] = Array.isArray(snapshot.agents)
+    ? snapshot.agents.map((raw: any) => {
+        const id = safeString(raw.aid ?? raw.id ?? "?");
+        const name = safeString(raw.name ?? `Agent ${id}`);
+        const x = safeNumber(raw.x ?? raw.pos?.[0]);
+        const y = safeNumber(raw.y ?? raw.pos?.[1]);
+        const inventory = raw.inventory || {};
+        const resources = Object.values(inventory).reduce((sum: number, value: any) => {
+          const amount = safeNumber(value);
+          return sum + amount;
+        }, 0);
+        const currentAction = typeof raw.current_action === "string" ? raw.current_action : null;
+        const action = safeString(currentAction).toLowerCase();
+        let status: AgentSummary["status"] = "idle";
+        if (action.includes("move")) status = "moving";
+        else if (action.includes("interact") || action.includes("fight") || action.includes("trade")) status = "engaged";
+        else if (action.includes("rest") || action.includes("recover")) status = "recovering";
+
+        return {
+          id,
+          name,
+          faction: safeString(raw.group_id ?? raw.faction ?? "Cohort"),
+          role: safeString(raw.role ?? (currentAction || "Citizen")),
+          morale: safeNumber(raw.health ?? raw.morale ?? 100),
+          resources,
+          location: { x, y },
+          status,
+          currentAction
+        };
+      })
+    : [];
+
+  const turnId = safeNumber(snapshot.turn ?? worldPayload.turn);
+  const revision = safeNumber(snapshot.revision ?? snapshot.turn_revision ?? 1, 1);
+  const rawTimestamp = snapshot.timestamp ?? snapshot.occurred_at;
+  let timestampSeconds: number;
+  if (typeof rawTimestamp === "number" && Number.isFinite(rawTimestamp)) {
+    timestampSeconds = rawTimestamp;
+  } else if (typeof rawTimestamp === "string") {
+    const numeric = Number(rawTimestamp);
+    if (Number.isFinite(numeric)) {
+      timestampSeconds = numeric;
+    } else {
+      const parsed = Date.parse(rawTimestamp);
+      timestampSeconds = Number.isFinite(parsed) ? parsed / 1000 : Date.now() / 1000;
+    }
+  } else {
+    timestampSeconds = Date.now() / 1000;
+  }
+  const occurredAt = typeof snapshot.occurred_at === "string"
+    ? new Date(snapshot.occurred_at).toISOString()
+    : new Date(timestampSeconds * 1000).toISOString();
+
+  const hash = safeString(snapshot.hash, `${turnId}-${revision}-${Math.round(timestampSeconds * 1000)}`);
+
+  const payload: TurnPayload = {
+    turnId,
+    revision,
+    hash,
+    occurredAt,
+    latencyMs: safeNumber(snapshot.latencyMs ?? snapshot.latency_ms),
+    events: Array.isArray(snapshot.events) ? snapshot.events : [],
+    agents,
+    cohorts: Array.isArray(snapshot.cohorts) ? snapshot.cohorts : [],
+    heatmap: Array.isArray(snapshot.heatmap) ? snapshot.heatmap : [],
+    interactions: Array.isArray(snapshot.interactions) ? snapshot.interactions : [],
+    world
+  };
+
+  return payload;
+}
+
+export function buildAgentActionMap(agents: AgentSummary[]): Record<string, string> {
+  const map: Record<string, string> = {};
+  for (const agent of agents) {
+    const label = agent.currentAction ? humanizeActionText(agent.currentAction) : STATUS_NAMES[agent.status] ?? "Idle";
+    map[agent.id] = label;
+  }
+  return map;
+}
+
+export function humanizeActionText(action: string): string {
+  if (!action) {
+    return "Idle";
+  }
+  return action
+    .replace(/[\[\]]/g, " ")
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(/\b(\w)/g, (match) => match.toUpperCase());
+}
+
+export interface NormalizedActionEvent {
+  interaction: InteractionRecord;
+  agentId: string | null;
+  actionText: string | null;
+}
+
+export function normalizeActionEvents(events: any[]): NormalizedActionEvent[] {
+  if (!Array.isArray(events)) {
+    return [];
+  }
+  return events.map((event: any) => {
+    const agentId =
+      event.aid != null
+        ? safeString(event.aid)
+        : event.agent_id != null
+          ? safeString(event.agent_id)
+          : null;
+    const actionText = typeof event.action === "string" ? humanizeActionText(event.action) : null;
+    const name = safeString(event.name ?? agentId ?? "Agent");
+    const turnId = safeNumber(event.turn);
+    let tsValue: number;
+    if (typeof event.timestamp === "number" && Number.isFinite(event.timestamp)) {
+      tsValue = event.timestamp;
+    } else if (typeof event.timestamp === "string") {
+      const numeric = Number(event.timestamp);
+      if (Number.isFinite(numeric)) {
+        tsValue = numeric;
+      } else {
+        const parsed = Date.parse(event.timestamp);
+        tsValue = Number.isFinite(parsed) ? parsed / 1000 : Date.now() / 1000;
+      }
+    } else {
+      tsValue = Date.now() / 1000;
+    }
+    const isoTimestamp = new Date(tsValue * 1000).toISOString();
+    const interaction: InteractionRecord = {
+      id: safeString(event.id, `act-${agentId ?? "unknown"}-${Math.round(tsValue * 1000)}`),
+      actor: "agent",
+      turnId,
+      intent: "Action",
+      content: `${name}: ${actionText ?? "Action"}`,
+      outcome: "",
+      timestamp: isoTimestamp
+    };
+    return { interaction, agentId, actionText };
+  });
+}
+
+export function normalizeLogEntries(entries: any[]): { timestamp: string; level: string; message: string }[] {
+  if (!Array.isArray(entries)) {
+    return [];
+  }
+  return entries.map((entry: any) => {
+    let ts: number;
+    if (typeof entry.timestamp === "number" && Number.isFinite(entry.timestamp)) {
+      ts = entry.timestamp;
+    } else if (typeof entry.timestamp === "string") {
+      const numeric = Number(entry.timestamp);
+      if (Number.isFinite(numeric)) {
+        ts = numeric;
+      } else {
+        const parsed = Date.parse(entry.timestamp);
+        ts = Number.isFinite(parsed) ? parsed / 1000 : Date.now() / 1000;
+      }
+    } else {
+      ts = Date.now() / 1000;
+    }
+    return {
+      timestamp: new Date(ts * 1000).toISOString(),
+      level: safeString(entry.level ?? "INFO").toUpperCase(),
+      message: safeString(entry.message ?? "")
+    };
+  });
+}

--- a/web_ui/monitor/src/styles/map-panel.css
+++ b/web_ui/monitor/src/styles/map-panel.css
@@ -5,6 +5,282 @@
   height: 100%;
 }
 
+.map-panel__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1.25rem;
+}
+
+.map-panel__heading p {
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary);
+  font-size: 0.9rem;
+}
+
+.map-panel__header-metrics {
+  display: grid;
+  grid-auto-flow: column;
+  gap: 0.75rem;
+  align-items: stretch;
+}
+
+.map-panel__stat {
+  min-width: 120px;
+  background: rgba(10, 16, 28, 0.55);
+  border: 1px solid rgba(123, 241, 168, 0.14);
+  border-radius: 12px;
+  padding: 0.55rem 0.7rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.map-panel__stat--warning {
+  border-color: rgba(255, 196, 112, 0.45);
+  background: rgba(255, 196, 112, 0.12);
+}
+
+.map-panel__stat--critical {
+  border-color: rgba(255, 118, 118, 0.5);
+  background: rgba(255, 118, 118, 0.12);
+}
+
+.map-panel__stat-label {
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+}
+
+.map-panel__stat-value {
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+
+.map-panel__stat-hint {
+  font-size: 0.7rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+}
+
+.map-panel__toolbar-group {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.map-panel__toolbar-group--layers {
+  flex: 1;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.map-panel__toolbar-group--meta {
+  margin-left: auto;
+  gap: 0.75rem;
+}
+
+.map-panel__slider-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__slider-label input[type="range"] {
+  accent-color: var(--accent-strong);
+}
+
+.map-panel__layer-toggle {
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid rgba(91, 140, 228, 0.35);
+  background: rgba(8, 12, 22, 0.6);
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  transition: all 0.2s ease;
+}
+
+.map-panel__layer-toggle--active {
+  color: var(--text-primary);
+  background: rgba(91, 140, 228, 0.18);
+  border-color: rgba(91, 140, 228, 0.55);
+  box-shadow: 0 0 0 1px rgba(91, 140, 228, 0.35);
+}
+
+.map-panel__theme-toggle {
+  display: inline-flex;
+  background: rgba(12, 18, 32, 0.7);
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  padding: 0.2rem;
+}
+
+.map-panel__theme-button {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  transition: background 0.2s ease, color 0.2s ease;
+}
+
+.map-panel__theme-button--active {
+  background: rgba(123, 241, 168, 0.2);
+  color: var(--text-primary);
+}
+
+.map-panel__timestamp {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__timestamp strong {
+  font-size: 0.88rem;
+  color: var(--text-primary);
+}
+
+.map-panel__intel-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.85rem;
+}
+
+.map-panel__intel-card {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 14px;
+  padding: 0.75rem 0.9rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  min-height: 94px;
+}
+
+.map-panel__intel-card--warning {
+  border-color: rgba(255, 196, 112, 0.38);
+  box-shadow: 0 0 0 1px rgba(255, 196, 112, 0.18);
+}
+
+.map-panel__intel-card--critical {
+  border-color: rgba(255, 118, 118, 0.45);
+  box-shadow: 0 0 0 1px rgba(255, 118, 118, 0.2);
+}
+
+.map-panel__intel-label {
+  font-size: 0.74rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+.map-panel__intel-value {
+  font-size: 1.2rem;
+  font-weight: 600;
+}
+
+.map-panel__intel-detail {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
+.map-panel__intel-secondary {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 0.9rem;
+}
+
+.map-panel__structures-summary,
+.map-panel__groups-summary {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 16px;
+  padding: 0.85rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.map-panel__structures-summary header,
+.map-panel__groups-summary header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+}
+
+.map-panel__structures-summary header span,
+.map-panel__groups-summary header span {
+  color: var(--text-secondary);
+  font-size: 0.78rem;
+}
+
+.map-panel__structure-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+}
+
+.map-panel__structure-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(123, 241, 168, 0.12);
+  border: 1px solid rgba(123, 241, 168, 0.25);
+  font-size: 0.74rem;
+}
+
+.map-panel__structure-chip strong {
+  font-weight: 600;
+  margin-left: 0.2rem;
+}
+
+.map-panel__structure-icon {
+  font-size: 0.9rem;
+}
+
+.map-panel__group-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.45rem;
+}
+
+.map-panel__group-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.map-panel__group-name {
+  font-weight: 600;
+}
+
+.map-panel__group-meta {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+}
+
 .map-panel__content {
   display: grid;
   grid-template-columns: minmax(0, 7fr) minmax(0, 5fr);
@@ -360,6 +636,32 @@
 }
 
 @media (max-width: 900px) {
+  .map-panel__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .map-panel__header-metrics {
+    grid-auto-flow: row;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    width: 100%;
+  }
+
+  .map-panel__toolbar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .map-panel__toolbar-group--layers {
+    justify-content: flex-start;
+  }
+
+  .map-panel__toolbar-group--meta {
+    margin-left: 0;
+    justify-content: space-between;
+    width: 100%;
+  }
+
   .map-panel__canvas-wrapper {
     padding: 0.75rem;
   }

--- a/web_ui/monitor/src/types/simulation.ts
+++ b/web_ui/monitor/src/types/simulation.ts
@@ -12,6 +12,7 @@ export interface AgentSummary {
     y: number;
   };
   status: "idle" | "moving" | "engaged" | "recovering";
+  currentAction?: string | null;
 }
 
 export interface CohortMetric {
@@ -31,10 +32,31 @@ export interface TileResources {
   [resource: string]: number;
 }
 
+export interface WorldStats {
+  total_agents: number;
+  active_agents: number;
+  total_groups: number;
+  total_resources: number;
+  technologies_discovered: number;
+}
+
+export interface WorldGroupSummary {
+  id: string;
+  name: string;
+  member_count: number;
+  reputation: number;
+  type: string;
+  leader?: string | null;
+}
+
 export interface WorldState {
   size: number;
   terrain: string[];
   resources: TileResources[];
+  era?: string;
+  turn?: number;
+  stats?: WorldStats;
+  groups?: WorldGroupSummary[];
 }
 
 export interface Structure {


### PR DESCRIPTION
## Summary
- add a bootstrap hook that periodically hydrates the monitor from /api/simulation-data and normalizes logs
- refactor websocket ingestion to reuse shared transformers, update log handling, and deduplicate turn frames in the store
- expose reusable snapshot transformers for actions/logs and extend the store for log replacement

## Testing
- npm run build *(fails: missing vitest/globals type definitions in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d5dd8fa0832687b10d65604b307f